### PR TITLE
Fix webirc hostnames

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,5 +29,8 @@ services:
     networks:
       - app-network
 networks:
-  app-network:
-    driver: bridge
+    app-network:
+      driver: bridge
+      ipam:
+          config:
+             - subnet: "172.50.0.0/16"

--- a/inspircd/conf/private/webirc.conf.example
+++ b/inspircd/conf/private/webirc.conf.example
@@ -1,1 +1,1 @@
-<cgihost type="webirc" mask="thelounge" password="secretpassword">
+<cgihost type="webirc" mask="172.50.0.0/16" password="secretpassword">


### PR DESCRIPTION
Creates a static subnet for the containers' network (172.50.x.x), uses that in inspircd's webirc mask.