### PR TITLE
Add acme-dns support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 secrets.js
 config.sh
 certs/
+acmedns/config/config.cfg

--- a/acmedns/README.md
+++ b/acmedns/README.md
@@ -1,0 +1,7 @@
+This directory is for self-hosting an acme-dns docker instance, useful for irc networks with multiple servers.
+
+Copy config.example.cfg to config.cfg and make changes, then run `docker-compose up -d`
+
+For more information:
+https://github.com/joohoi/acme-dns
+

--- a/acmedns/config/config.example.cfg
+++ b/acmedns/config/config.example.cfg
@@ -1,0 +1,65 @@
+[general]
+# DNS interface. Note that systemd-resolved may reserve port 53 on 127.0.0.53
+# In this case acme-dns will error out and you will need to define the listening interface
+# for example: listen = "127.0.0.1:53"
+listen = "0.0.0.0:53"
+# protocol, "both", "both4", "both6", "udp", "udp4", "udp6" or "tcp", "tcp4", "tcp6"
+protocol = "both"
+# domain name to serve the requests off of
+domain = "auth.example.org"
+# zone name server
+nsname = "auth.example.org"
+# admin email address, where @ is substituted with .
+nsadmin = "admin.example.org"
+# predefined records served in addition to the TXT
+records = [
+    # domain pointing to the public IP of your acme-dns server 
+    "auth.example.org. A 198.51.100.1",
+    # specify that auth.example.org will resolve any *.auth.example.org records
+    "auth.example.org. NS auth.example.org.",
+]
+# debug messages from CORS etc
+debug = false
+
+[database]
+# Database engine to use, sqlite3 or postgres
+engine = "sqlite3"
+# Connection string, filename for sqlite3 and postgres://$username:$password@$host/$db_name for postgres
+# Please note that the default Docker image uses path /var/lib/acme-dns/acme-dns.db for sqlite3
+connection = "/var/lib/acme-dns/acme-dns.db"
+# connection = "postgres://user:password@localhost/acmedns_db"
+
+[api]
+# listen ip eg. 127.0.0.1
+ip = "0.0.0.0"
+# disable registration endpoint
+disable_registration = false
+# listen port, eg. 443 for default HTTPS
+port = "443"
+# possible values: "letsencrypt", "letsencryptstaging", "cert", "none"
+tls = "letsencrypt"
+# only used if tls = "cert"
+tls_cert_privkey = "/etc/tls/example.org/privkey.pem"
+tls_cert_fullchain = "/etc/tls/example.org/fullchain.pem"
+# only used if tls = "letsencrypt"
+acme_cache_dir = "api-certs"
+# optional e-mail address to which Let's Encrypt will send expiration notices for the API's cert
+notification_email = ""
+# CORS AllowOrigins, wildcards can be used
+corsorigins = [
+    "*"
+]
+# use HTTP header to get the client ip
+use_header = false
+# header name to pull the ip address / list of ip addresses from
+header_name = "X-Forwarded-For"
+
+[logconfig]
+# logging level: "error", "warning", "info" or "debug"
+loglevel = "debug"
+# possible values: stdout, TODO file & integrations
+logtype = "stdout"
+# file path for logfile TODO
+# logfile = "./acme-dns.log"
+# format, either "json" or "text"
+logformat = "text"

--- a/acmedns/data/.gitignore
+++ b/acmedns/data/.gitignore
@@ -1,0 +1,1 @@
+acme-dns.db

--- a/acmedns/docker-compose.yml
+++ b/acmedns/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '2'
+services:
+  acmedns:
+    image: joohoi/acme-dns:latest
+    ports:
+      - "443:443"
+      - "53:53"
+      - "53:53/udp"
+    volumes:
+      - ./config:/etc/acme-dns:ro
+      - ./data:/var/lib/acme-dns

--- a/config.example.sh
+++ b/config.example.sh
@@ -4,3 +4,5 @@ name='user'
 # If you change these after install, run update.sh to apply new certs.
 domain=('domain' 'optional' 'domains')
 email='admin@domain.com'
+# Don't include http(s):// or www. in the host.
+acmehost='auth.domain.com'

--- a/inspircd/Dockerfile
+++ b/inspircd/Dockerfile
@@ -2,9 +2,9 @@ FROM debian:buster
 MAINTAINER Yam (yam@wetfish.net)
 RUN apt update && apt-get install -y apt-transport-https
 RUN apt-get -y install wget build-essential tar pkg-config gnutls-bin libgnutls28-dev certbot wget
-RUN wget https://github.com/inspircd/inspircd/archive/v3.8.1.tar.gz
-RUN tar -xvf v3.8.1.tar.gz
-WORKDIR inspircd-3.8.1/
+RUN wget https://github.com/inspircd/inspircd/archive/v3.9.0.tar.gz
+RUN tar -xvf v3.9.0.tar.gz
+WORKDIR inspircd-3.9.0/
 RUN addgroup --system --gid 10000 inspircd
 RUN adduser --system --uid 10000 --home /inspircd/ --group inspircd
 RUN ./configure --prefix /inspircd --uid 10000 --gid 10000

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ NC='\033[0m'
 
 apt-get install -y docker docker-compose certbot
 
-certbot certonly --force-renewal --agree-tos --non-interactive --standalone -m $email -d ${joined_domains%-d }
+acquire_certs
 
 printf "${GREEN}Creating ${name} user${NC}\n"
 

--- a/update.sh
+++ b/update.sh
@@ -8,7 +8,9 @@ rm -rf /etc/letsencrypt/live/*
 rm -rf /etc/letsencrypt/archive/*
 rm -rf /etc/letsencrypt/renewal/*
 #certbot delete -n --cert-name ${domain[@]}
-certbot certonly --force-renewal --agree-tos --non-interactive --standalone -m $email -d ${joined_domains%-d }
+
+acquire_certs
+
 ./cronjob.sh
 
 ## Todo: add acme-dns support

--- a/util.sh
+++ b/util.sh
@@ -15,3 +15,22 @@ if [ -z "$name" ] || [ -z "$domain" ] || [ -z "$email" ]; then
     exit
 fi
 
+if [ ! -z "$acmehost" ]; then
+    if [ ! -f /etc/letsencrypt/acme-dns-auth.py ]; then 
+        curl -o /etc/letsencrypt/acme-dns-auth.py https://raw.githubusercontent.com/joohoi/acme-dns-certbot-joohoi/master/acme-dns-auth.py
+        chmod 0700 /etc/letsencrypt/acme-dns-auth.py
+    fi
+    usingAcmeDns=true;
+    else
+    usingAcmeDns=false;
+fi
+
+acquire_certs () {
+    if $usingAcmeDns; then
+        ## Update acme-dns config in hook script in case we've changed it in config.sh..
+        sed -i "1,/.*ACMEDNS_URL.*/{s/.*ACMEDNS_URL.*/ACMEDNS_URL = \"https:\/\/$acmehost\"/;}" /etc/letsencrypt/acme-dns-auth.py
+        certbot certonly --force-renewal --agree-tos --manual-public-ip-logging-ok -m $email --manual --manual-auth-hook /etc/letsencrypt/acme-dns-auth.py --preferred-challenges dns --debug-challenges -d ${joined_domains%-d }
+    else
+        certbot certonly --force-renewal --agree-tos --non-interactive --standalone -m $email -d ${joined_domains%-d }
+    fi
+}


### PR DESCRIPTION
Adds functionality to the scripts to support using an acme-dns server for dns certificate challenges.